### PR TITLE
Update ts-loader to the latest version 🚀

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "rimraf": "^2.6.1",
     "sinon": "^1.17.7",
     "sinon-chai": "^2.8.0",
-    "ts-loader": "^2.0.1",
+    "ts-loader": "^2.0.2",
     "ts-node": "^2.1.0",
     "tslint": "^4.5.1",
     "typedoc": "^0.5.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4649,9 +4649,9 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
-ts-loader@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/ts-loader/-/ts-loader-2.0.1.tgz#2ec8fa5e20ef01062a4a2c28c9d6ac828c32e75d"
+ts-loader@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/ts-loader/-/ts-loader-2.0.2.tgz#74abc2f15a9f1d8432873dfa35eef8e513caa622"
   dependencies:
     colors "^1.0.3"
     enhanced-resolve "^3.0.0"


### PR DESCRIPTION
## Version **2.0.2** of [ts-loader](https://github.com/TypeStrong/ts-loader) just got published.

<table>
  <tr>
    <th align=left>
      Dependency
    </td>
    <td>
      ts-loader
    </td>
  </tr>
  <tr>
    <th align=left>
      Current Version
    </td>
    <td>
      2.0.1
    </td>
  </tr>
  <tr>
    <th align=left>
      Type
    </td>
    <td>
      devDependency
    </td>
  </tr>
</table>